### PR TITLE
Avoid XML namespace hack and use a SOH  char instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A huge thanks to [Nicolò Ribaudo](https://twitter.com/NicoloRibaudo) for helpin
 ```js
 {
   "plugins": [
-    ["@babel/plugin-transform-react-jsx", {"throwIfNamespace": false}],
+    ["@babel/plugin-transform-react-jsx"],
     ["module:@ungap/plugin-transform-static-jsx"]
   ]
 }

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
-    ["@babel/plugin-transform-react-jsx", {"throwIfNamespace": false}],
+    ["@babel/plugin-transform-react-jsx"],
     ["./esm/index.js"]
   ]
 }

--- a/cjs/index.js
+++ b/cjs/index.js
@@ -1,6 +1,8 @@
 'use strict';
 const {escape} = require('html-escaper');
 
+const PREFIX = '\x01';
+
 /*! (c) Andrea Giammarchi & Nicolò Ribaudo - ISC */
 module.exports = ({types: t}) => ({
   visitor: {
@@ -8,13 +10,14 @@ module.exports = ({types: t}) => ({
       const {node: {name, value}, parent} = path;
 
       if (
+        name.name[0] === PREFIX ||
+        /^[A-Z]/.test(parent.name.name) ||
         t.isJSXNamespacedName(name) ||
-        t.isJSXExpressionContainer(value) ||
-        /^[A-Z]/.test(parent.name.name)
+        t.isJSXExpressionContainer(value)
       )
         return;
 
-      path.set('name', t.jsxNamespacedName(t.jsxIdentifier(''), name));
+      path.set('name', t.jsxIdentifier(PREFIX + name.name));
 
       if (t.isStringLiteral(value))
         value.value = escape(value.value);

--- a/esm/index.js
+++ b/esm/index.js
@@ -1,5 +1,7 @@
 import {escape} from 'html-escaper';
 
+const PREFIX = '\x01';
+
 /*! (c) Andrea Giammarchi & Nicolò Ribaudo - ISC */
 export default ({types: t}) => ({
   visitor: {
@@ -7,13 +9,14 @@ export default ({types: t}) => ({
       const {node: {name, value}, parent} = path;
 
       if (
+        name.name[0] === PREFIX ||
+        /^[A-Z]/.test(parent.name.name) ||
         t.isJSXNamespacedName(name) ||
-        t.isJSXExpressionContainer(value) ||
-        /^[A-Z]/.test(parent.name.name)
+        t.isJSXExpressionContainer(value)
       )
         return;
 
-      path.set('name', t.jsxNamespacedName(t.jsxIdentifier(''), name));
+      path.set('name', t.jsxIdentifier(PREFIX + name.name));
 
       if (t.isStringLiteral(value))
         value.value = escape(value.value);

--- a/test/output.js
+++ b/test/output.js
@@ -2,18 +2,18 @@ function Component({
   className
 }) {
   return /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement("div", {
-    ":id": "my-div",
+    "\x01id": "my-div",
     className: className
   }, /*#__PURE__*/React.createElement("p", {
     color: color,
-    ":label": "f&quot;o",
+    "\x01label": "f&quot;o",
     hidden: true
   })), /*#__PURE__*/React.createElement("div", {
-    ":id": "my-div",
+    "\x01id": "my-div",
     className: className
   }, /*#__PURE__*/React.createElement("p", {
     color: color,
-    ":label": "f&amp;o",
-    ":data-attr": "2"
+    "\x01label": "f&amp;o",
+    "\x01data-attr": "2"
   })));
 }


### PR DESCRIPTION
Apparently the XML empty namespace hack might be not future friendly, so that using just a regular namespace but an invalid char (in the JSX) should do the trick too.
